### PR TITLE
Fix xdg-desktop-portal-wlr not activating correctly

### DIFF
--- a/home/.config/sway/config
+++ b/home/.config/sway/config
@@ -182,3 +182,20 @@ exec rm -f /tmp/sov && mkfifo /tmp/sov && tail -f /tmp/sov | sov -v -t 200 -k 65
 exec brightnessctl set 50%v
 exec ~/.config/wcp/wcp.sh
 exec ~/.config/wfl/wfl.sh
+
+# sway does not set DISPLAY/WAYLAND_DISPLAY in the systemd user environment
+# See FS#63021
+# Adapted from xorg's 50-systemd-user.sh, which achieves a similar goal.
+
+# Upstream refuses to set XDG_CURRENT_DESKTOP so we have to.
+exec systemctl --user set-environment XDG_CURRENT_DESKTOP=sway
+exec systemctl --user import-environment DISPLAY \
+                                         SWAYSOCK \
+                                         WAYLAND_DISPLAY \
+                                         XDG_CURRENT_DESKTOP
+
+exec hash dbus-update-activation-environment 2>/dev/null && \
+     dbus-update-activation-environment --systemd DISPLAY \
+                                                  SWAYSOCK \
+                                                  XDG_CURRENT_DESKTOP=sway \
+                                                  WAYLAND_DISPLAY


### PR DESCRIPTION
Xdg-desktop-portal not working out-of-the-box in Debian 12 (not tried in void linux) because WAYLAND_DISPLAY and XDG_CURRENT_DESKTOP are not set in systemd and dbus environment.

The script was taken from sway archlinux package.
[https://gitlab.archlinux.org/archlinux/packaging/packages/sway/-/blob/main/50-systemd-user.conf?ref_type=heads](url)